### PR TITLE
Fix percentile action and summary functions, fixed summary Test, fixed error message

### DIFF
--- a/R/action.R
+++ b/R/action.R
@@ -111,7 +111,20 @@ runAction <-  function(CASorCASTab='', actn, check_errors=FALSE, ...) {
       {
       tp  = swat::gen.table.parm(CASorCASTab)
       cas = CASorCASTab@conn
-      pms = list('caz'=cas, 'actn'=actn, 'table'=tp[!names(tp) == "vars"], ...)
+      pms = list('caz'=cas, 'actn'=actn)
+      
+      if (actn %in% c("percentile.percentile", "percentile.assess", "percentile.boxPlot")) {
+        
+        nvars = swat::numericVarList(CASorCASTab)
+        inputs = lapply(nvars, function(x) list(name = x))
+        
+        pms = append(pms, list('table'=tp[names(tp) != "vars"], 
+                               "inputs" = inputs,
+                               ...))
+      } else {
+        pms = append(pms, list('table'=tp, ...))
+      }
+      
       res <- do.call('casRetrieve', pms)
       }
    else
@@ -137,11 +150,15 @@ runAction <-  function(CASorCASTab='', actn, check_errors=FALSE, ...) {
          gen.functions(cas, actionSet)
          swat::check_for_cas_errors(res)
          }
-      else
+      else if (class(CASorCASTab) == "CAS")
          {
          pms = list('caz'=cas, 'actn'=actn, ...)
          res <- do.call('casRetrieve', pms)
          }
+      else {
+        stop("Not a CasTable or CAS connection")
+      }
+      
       }
 
   if (check_errors)

--- a/R/action.R
+++ b/R/action.R
@@ -111,7 +111,7 @@ runAction <-  function(CASorCASTab='', actn, check_errors=FALSE, ...) {
       {
       tp  = swat::gen.table.parm(CASorCASTab)
       cas = CASorCASTab@conn
-      pms = list('caz'=cas, 'actn'=actn, 'table'=tp, ...)
+      pms = list('caz'=cas, 'actn'=actn, 'table'=tp[!names(tp) == "vars"], ...)
       res <- do.call('casRetrieve', pms)
       }
    else

--- a/R/descriptive_stats.R
+++ b/R/descriptive_stats.R
@@ -129,7 +129,7 @@ setMethod("median",
           {
             tp = swat::gen.table.parm(x)
             nvars <- swat::numericVarList(x)
-            res <- casRetrieve(x@conn, 'percentile.percentile', table=tp, inputs=nvars, values='50')
+            res <- casRetrieve(x@conn, 'percentile.percentile', table=tp[!names(tp) == "vars"], inputs=nvars, values='50')
             return (as.numeric(res$results$Percentile$Value))
           })
 
@@ -556,7 +556,7 @@ cas.median <- function(CASTable, q){
   x <- CASTable
   tp = swat::gen.table.parm(x)
   nvars <- swat::numericVarList(x)
-  res <- casRetrieve(x@conn, 'percentile.percentile', table=tp, inputs=nvars, values=list('50'))
+  res <- casRetrieve(x@conn, 'percentile.percentile', table=tp[!names(tp) == "vars"], inputs=nvars, values=list('50'))
   check_for_cas_errors(res)
   m <- res$results$Percentile
   colnames(m)[3] <- "Median"
@@ -665,7 +665,7 @@ cas.quantile <- function(CASTable, q){
   x <- CASTable
   tp = swat::gen.table.parm(x)
   nvars <- swat::numericVarList(x)
-  res <- casRetrieve(x@conn, 'percentile.percentile', table=tp, inputs=nvars, values=as.list(q))
+  res <- casRetrieve(x@conn, 'percentile.percentile', table=tp[!names(tp) == "vars"], inputs=nvars, values=as.list(q))
   check_for_cas_errors(res)
   return(res$results$Percentile[1:3])
 }
@@ -1042,13 +1042,13 @@ setMethod("summary",
               }
             }
             # get distinct counts for NA's (missing values)
-            distinct_res <- casRetrieve(object@conn, 'simple.distinct', table=tp)
+            distinct_res <- casRetrieve(object@conn, 'simple.distinct', table=tp[!names(tp) == "vars"])
             if (length(nvars) > 0)
             {
               # get statistics for numeric variables
               nres <- casRetrieve(object@conn, 'simple.summary', table=tp, inputs=nvars, subSet=list("NMISS", "MIN", "MEAN", "MAX"))
               ret = nres$results$Summary
-              pctres <- casRetrieve(object@conn, 'percentile.percentile', table=tp, inputs=nvars, values=list('25', '50', '75'))
+              pctres <- casRetrieve(object@conn, 'percentile.percentile', table=tp[!names(tp) == "vars"], inputs=nvars, values=list('25', '50', '75'))
               pet <- pctres$results$Percentile
             }
             

--- a/R/read_write.R
+++ b/R/read_write.R
@@ -757,7 +757,7 @@ cas.read.table <- function (conn, file, header = FALSE, sep = "", quote = "\"'",
                             colClasses = NA, nrows = -1, skip = 0, check.names = TRUE,
                             fill = !blank.lines.skip, strip.white = FALSE, blank.lines.skip = TRUE,
                             comment.char = "#", allowEscapes = FALSE, flush = FALSE,
-                            stringsAsFactors = default.stringsAsFactors(), fileEncoding = "",
+                            stringsAsFactors = FALSE, fileEncoding = "",
                             encoding = "unknown", text, skipNul = FALSE, 
                             casOut = list(name='', replace=FALSE)
 ) {

--- a/R/swat.R
+++ b/R/swat.R
@@ -1866,7 +1866,7 @@ cas2r <- function(sw_value) {
       int64_missval <- '-9223372036854775808'
       setMissing <- function (value, missval)
       {
-          value[is.na(value) || is.nan(value) || value == missval] <- NA
+          value[is.na(value) | is.nan(value) | value == missval] <- NA
           return(value)
       }
 

--- a/tests/testthat/test.analysis_compvars.R
+++ b/tests/testthat/test.analysis_compvars.R
@@ -97,6 +97,5 @@ test_that("cor, cov", {
 })
 
 test_that("summary", {
-  skip("Issue 72")
-  expect_true(all.equal(summary(ct_cmp[c(1:4,7:8)]), summary(df_cmp[c(1:4,7:8)]), check.attributes=FALSE))
+  expect_true(all.equal(summary(ct_cmp[c(1:4,7:8)]), summary(df_cmp[c(1:4,7:8)], quantile.type = 2), check.attributes = FALSE))
 })


### PR DESCRIPTION
I will go through each fix file by file:

1.  `R/action.R` and `R/descriptive_stats.R`

In the latest Viya 2022.12 there was a change in the `percentile.percentile` action which breaks all the calls to that action within the implemented methods that uses this function (summary, median and quantile).

`summary(castbl)` and `cas.percentile.percentile(castbl)` will fail with `table.vars` argument being invalid, due to the removal of that variable from the action's backend, causing call to fail.

It only affects `cas.percentile.percentile`, when the `CasTable` object is being used. 

The solution proposed is to remove the "vars" parameter when calling any action using a `CasTable` object, since it only brings all the variable names which are redundant, CAS should still return results for all data, and still be compatible with prior CAS versions. 

This is probably not the most elegant solution, but it would require changing/removing `swat::gen.table.param()` and any code that relies on it and moving to usage of CasTable objects directly `castabl@tname` and `castbl@caslib` instead since it is more of a helper.

It also fixed a minor issue when calling `simple.distinct` inside the `summary` method which would cause the computed vars to response to be duplicated.

2. `R/read_write.R`

This removed the usage of a deprecated function `default.StringsAsFactors()` to the default values `FALSE`. It may affect R from prior 4.0 but it is very unlikely.

3. `R/swat.R`

It fixes the warning messages from the issue #41 . It should check all variables in the vector and return logic for each value instead of once for the whole vector.

4. `tests/testthat/test.analysis_compvars.R`

This should fix a long lasting testing issue (internal gilab error of number 72) where the CAS summary was mismatching from R summary. The fix is to pass the correct parameter `summary` method (for `summary.data.frame`) when calling the `percentile()`, the `percentile.type = 2` argument returns a matching test.
