### PR TITLE
Fix Issue #46 dataStep action failing on Rest Protocol

### DIFF
--- a/R/rswat_rest.R
+++ b/R/rswat_rest.R
@@ -174,8 +174,9 @@ REST_CASTable <- setRefClass(
             out <- do.call(rbind.data.frame, out)
             
             if (length(names(out)) > 0 ) {
-            names(out) <- col.names
+              names(out) <- col.names
             }
+            
             return( out )
         },
 

--- a/R/rswat_rest.R
+++ b/R/rswat_rest.R
@@ -172,8 +172,10 @@ REST_CASTable <- setRefClass(
             # Convert rows of data to data.frame
             out$stringsAsFactors = FALSE
             out <- do.call(rbind.data.frame, out)
+            
+            if (length(names(out)) > 0 ) {
             names(out) <- col.names
-
+            }
             return( out )
         },
 


### PR DESCRIPTION
Added a table length verification to fix Issue #46 which an action would fail on rest protocol. 

If it the action would return an empty `data.frame` it will skip the column renaming which was causing the issue. It will return the correct InputCasTables and OutputCasTables information.

```r
library("swat")

con <- CAS(..., protocol = "http")

ds1 <- "data casuser.a;

        do i = 1 to 1000;
            j = i + 1;
            output;
        end;
  run;
"

cas.dataStep.runCode(con, code = ds1)
```

```r
$InputCasTables
[1] casLib  Name    Rows    Columns
<0 linhas> (ou row.names de comprimento 0)

$OutputCasTables
        casLib Name   Rows Columns Append Promoted
1 CASUSER(sas)    a 120000       2    NaN        N
```