### PR TITLE
Enable SAS binaries on Linux

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,3 +47,4 @@ Collate:
     'connection_viewer.R'
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
+SystemRequirements: NUMA (deb) or numactl-devel (rpm)

--- a/R/helper.R
+++ b/R/helper.R
@@ -292,7 +292,8 @@ download_sas_binaries <- function(libpath = .libPaths()){
   installed_lib_paths = paste0("R-swat-", pkg_ver, "/inst/libs")
 
   untar(tempfile, files = installed_lib_paths, exdir = temp)
-  file.rename(file.path(temp, installed_lib_paths), file.path(libpath, "libs"))
+  dir.create(file.path(libpath, "libs"),recursive = TRUE)
+  file.copy(file.path(temp, installed_lib_paths), file.path(libpath), recursive = TRUE)
 
   message("Restart your R session and reload swat to enable binary connection")
 }


### PR DESCRIPTION
With a current version of `R-swat` on Linux I get 

```
> swat::download_sas_binaries()
trying URL '[redacted]'
Content type 'application/octet-stream' length 45032825 bytes (42.9 MB)
==================================================
downloaded 42.9 MB

Restart your R session and reload swat to enable binary connection
Warning message:
In file.rename(file.path(temp, installed_lib_paths), file.path(libpath,  :
  cannot rename file '/tmp/RtmpnOnRG3/R-swat-1.10.0/inst/libs' to '/home/mmwork/R/x86_64-pc-linux-gnu-library/4.5/swat/libs', reason 'Invalid cross-device link'
```

The PR is fixing this issue by replacing the `file.rename()` command in `helper.R` into a `file.copy()` and `dir.create()` function call.

Since one of the binaries also depends on NUMA, a `SystemRequirements` field for NUMA is added as well. Once approved, https://github.com/rstudio/r-system-requirements/ can be updated so that essential system dependencies for the binaries are automatically picked up when run by tools such as r-lib/pak or the same information exposed by Posit Package Manager. 

Furthermore, when using the SAS binaries, checking `ldd` in the `libs` folder of the installed R package reveals more missing DLL's that comprise additional SystemRequirements, e.g. 

```
        libdfssys-1.3.so => not found
        libdfsfio-1.5.so => not found
        libdflic-1.4.so => not found
        libdfschr-1.4.so => not found
        libdfsfio-1.5.so => not found
        libdfssys-1.3.so => not found
        libdfschr-1.4.so => not found
        libdfssys-1.3.so => not found
        libdfschr-1.4.so => not found
./libicui18n.so: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /home/mmwork/R/x86_64-pc-linux-gnu-library/4.5/swat/libs/./libicuuc.so)
./libicuuc.so: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by ./libicuuc.so)
        libarrow.so.14 => not found
        libmariadb.so.3 => not found
        libmariadb.so.3 => not found
        libnlplib.so => not found
        libtorch.so => not found
        libtorch_cpu.so => not found
        libtorch_cuda.so => not found
        libc10.so => not found
        libc10_cuda.so => not found
        libnlplib.so => not found
        librdkafka.so.1 => not found
        libionc.so.1.0.3 => not found
        libnvidia-ml.so.1 => not found
        libcuda.so.1 => not found
        libhiredis.so.1.1.0 => not found
        libhiredis_ssl.so.1.1.0 => not found
        librdkafka.so.1 => not found
        librabbitmq.so.4 => not found  
``` 

Not sure how critical these are for the general functioning of the binaries and the R package. 